### PR TITLE
jquery-johnnys-path 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# jquery-johnnys-path [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/jquery-johnnys-path.svg)](https://www.npmjs.com/package/jquery-johnnys-path) [![Downloads](https://img.shields.io/npm/dt/jquery-johnnys-path.svg)](https://www.npmjs.com/package/jquery-johnnys-path) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# jquery-johnnys-path
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/jquery-johnnys-path.svg)](https://www.npmjs.com/package/jquery-johnnys-path) [![Downloads](https://img.shields.io/npm/dt/jquery-johnnys-path.svg)](https://www.npmjs.com/package/jquery-johnnys-path) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > A small jQuery plugin that animates an absolute positioned element according to a path you give.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-johnnys-path",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A small jQuery plugin that animates an absolute positioned element according to a path you give.",
   "main": "lib/index.js",
   "scripts": {
@@ -29,6 +29,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
